### PR TITLE
No need for calculation of test method name.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,17 @@ PATH
   remote: .
   specs:
     minitest-metadata (0.1.0)
+      minitest (>= 2.12)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    minitest (2.10.1)
+    minitest (2.12.0)
+    rake (0.9.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (>= 2.5)
   minitest-metadata!
+  rake

--- a/lib/minitest-metadata.rb
+++ b/lib/minitest-metadata.rb
@@ -19,11 +19,9 @@ class MiniTest::Spec
 
     # @private
     def it(description = "", metadata = {}, &block)
-      methods = test_methods
-      ret = old_it description, &block
-      name = (test_methods - methods).first
-      self.metadata[name] = metadata
-      ret
+      old_it(description, &block).tap do |name|
+        self.metadata[name] = metadata
+      end
     end
   end
 end

--- a/minitest-metadata.gemspec
+++ b/minitest-metadata.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "minitest", ">= 2.12"
+
   s.add_development_dependency "rake"
-  s.add_development_dependency "minitest", ">= 2.5"
 end


### PR DESCRIPTION
Since minitest 2.12.0 ::it returns test method name
so we don't have to determine this using expensive operation anymore.
