### PR TITLE
minitest-metadata performance improvements

### DIFF
--- a/lib/minitest/metadata.rb
+++ b/lib/minitest/metadata.rb
@@ -15,20 +15,17 @@ module MiniTest::Metadata
 
         # @private
         def it(description = "", *metadata, &block)
-          old_it(description, &block).tap do |name|
-            self.metadata[name] = _compute_metadata(metadata)
-          end
+          name = old_it(description, &block)
+          self.metadata[name] = _compute_metadata(metadata) if metadata
         end
 
         def _compute_metadata(metadata)
-          metadata.inject({}) { |hash, key|
-            if key.is_a?(Hash)
-              hash.merge!(key)
-            else
-              hash[key] = true
-            end
-            hash
-          }
+          meta = {}
+          if metadata[-1].is_a? Hash
+            meta.merge!(metadata.pop)
+          end
+          metadata.each { |key| meta[key] = true }
+          meta
         end
       end
 

--- a/lib/minitest/metadata.rb
+++ b/lib/minitest/metadata.rb
@@ -20,9 +20,10 @@ module MiniTest::Metadata
         end
 
         def _compute_metadata(metadata)
-          meta = {}
           if metadata[-1].is_a? Hash
-            meta.merge!(metadata.pop)
+            meta = metadata.pop
+          else
+            meta = {}
           end
           metadata.each { |key| meta[key] = true }
           meta

--- a/lib/minitest/metadata.rb
+++ b/lib/minitest/metadata.rb
@@ -2,7 +2,7 @@ module MiniTest::Metadata
   module ClassMethods
     # Returns Hash metadata for class' test methods
     def metadata
-      @metadata ||= {}
+      @metadata ||= Hash.new({})
     end
   end
 
@@ -16,7 +16,8 @@ module MiniTest::Metadata
         # @private
         def it(description = "", *metadata, &block)
           name = old_it(description, &block)
-          self.metadata[name] = _compute_metadata(metadata) if metadata
+          self.metadata[name] = _compute_metadata(metadata) unless metadata.empty?
+          name
         end
 
         def _compute_metadata(metadata)

--- a/test/minitest/metadata_test.rb
+++ b/test/minitest/metadata_test.rb
@@ -23,6 +23,16 @@ describe 'MiniTest::Spec' do
     @cls.metadata["test_0004_test4"].must_equal :vcr => true, :js => false
   end
 
+  it "new ::it returns the name of the test method" do
+    @cls = describe "A spec" do
+      include MiniTest::Metadata
+
+      @name = it "test1" do; end
+    end
+
+    @cls.instance_variable_get(:@name).must_equal "test_0001_test1"
+  end
+
   it "#meta returns empty hash when nothing passed to ::it" do
     metadata.must_equal({})
   end


### PR DESCRIPTION
This PR improves performance of minitest-metadata metadata processing by up to 50%.  See this gist: https://gist.github.com/tmertens/9a3355c3c9a04d537a34

The two caveats here are:
- It requires any hash metadata to appear at the end of the argument list, but this conforms to standard ruby practices.
- If a hash metadata appears at the end of the metadata argument list, other metadata args will be added to that hash rather than instantiating a new hash.  This change is based on the expectation that metadata is generally applied to each method individually and not to two or more methods using a single stored variable.  This gives an additional 25-30% performance boost to metadata args which include a hash.

I have never seen variables used for metadata hashes in the wild myself, but if this is an issue, the second commit can be easily reverted.
